### PR TITLE
changed line 173 in __str__ method in  src/semantics.py

### DIFF
--- a/src/ultk/language/semantics.py
+++ b/src/ultk/language/semantics.py
@@ -170,4 +170,4 @@ class Meaning(Generic[T]):
         return bool(self.mapping)  # and bool(self.universe)
 
     def __str__(self):
-        return f"Mapping:\n\t{'\n'.join(f"{ref}: {self.mapping[ref]}" for ref in self.mapping)}"# \ \nDistribution:\n\t{self.dist}\n"
+        return "Mapping:\n\t{0}".format('\n'.join(f"{ref}: {self.mapping[ref]}" for ref in self.mapping)) # \ \nDistribution:\n\t{self.dist}\n"


### PR DESCRIPTION
line 173 is return value of __str__ method in semantics.py. The original return statement
`return f"Mapping:\n\t{'\n'.join(f"{ref}: {self.mapping[ref]}" for ref in self.mapping)}"`
threw an error:![image](https://github.com/user-attachments/assets/db594272-77da-49dc-b52a-b31de2700e33)

Changed line to :
`return "Mapping:\n\t{0}".format('\n'.join(f"{ref}: {self.mapping[ref]}" for ref in self.mapping))`