### PR TITLE
Add `count_atoms` to `GrammaticalExpression`

### DIFF
--- a/src/tests/test_grammar.py
+++ b/src/tests/test_grammar.py
@@ -33,6 +33,10 @@ class TestGrammar:
     def test_length(self):
         parsed_expression = TestGrammar.grammar.parse(TestGrammar.geq2_expr_str)
         assert len(parsed_expression) == 5
+    
+    def test_atom_count(self):
+        parsed_expression = TestGrammar.grammar.parse(TestGrammar.geq2_expr_str)
+        assert parsed_expression.count_atoms() == 3
 
     def test_yield(self):
         parsed_expression = TestGrammar.grammar.parse(TestGrammar.geq2_expr_str)

--- a/src/ultk/language/grammar.py
+++ b/src/ultk/language/grammar.py
@@ -176,10 +176,7 @@ class GrammaticalExpression(Expression[T]):
     def count_atoms(self):
         if self.children is None:
             return 1
-        length = 0
-        if self.children is not None:
-            length += sum(child.count_atoms() for child in self.children)
-        return length
+        return sum(child.count_atoms() for child in self.children)
 
     @classmethod
     def from_dict(cls, the_dict: dict, grammar: "Grammar") -> "GrammaticalExpression":

--- a/src/ultk/language/grammar.py
+++ b/src/ultk/language/grammar.py
@@ -171,6 +171,15 @@ class GrammaticalExpression(Expression[T]):
         if self.children:
             the_dict["children"] = tuple(child.to_dict() for child in self.children)
         return the_dict
+    
+    # Following function counts the total number of atoms / leaf nodes, as opposed to __len__, which counts all nodes
+    def count_atoms(self):
+        if self.children is None:
+            return 1
+        length = 0
+        if self.children is not None:
+            length += sum(child.count_atoms() for child in self.children)
+        return length
 
     @classmethod
     def from_dict(cls, the_dict: dict, grammar: "Grammar") -> "GrammaticalExpression":


### PR DESCRIPTION
- This pull request will add the method `count_atoms` to the class `GrammaticalExpression`, as suggested by #42.
- This also adds the test `test_atom_count` to `test_grammar.py`.

### Notes
- When implementing the test in `test_grammar.py`, numerous issues with testing came up
  - `test_grammar.py` and `test_language.py` both have issues with `Universe` expecting a tuple of `prior`s
  - `test_language.py` also has some issues with a `Meaning` being initialized incorrectly
  - `test_meaning` in `test_grammar.py` fails (even after changes are reverted)
  - However after implementing temporary workarounds, `test_atom_count` does pass
- As mentioned in #42. `count_atoms` can also be moved to a helper method in `grammar.py`, I simply felt it was more in line with the current project structure to make it a method of the `GrammaticalExpression` class