### PR TITLE
Add new features for Metropolis-Hastings sampler

### DIFF
--- a/src/tests/test_likelihood.py
+++ b/src/tests/test_likelihood.py
@@ -1,0 +1,38 @@
+from ultk.language.grammar.likelihood import all_or_nothing, percent_match_unique, percent_match, noise_match
+from math import log
+
+# The expression can simply act as a function for this purpose
+def expression(_):
+    return True
+
+def even(i):
+    return i % 2 == 0
+
+class TestLikelihood:
+    all_true = [(i, True) for i in range(10)]
+    all_false = [(i, False) for i in range(10)]
+    half = [(i, i%2 == 0) for i in range(10)]
+
+    def test_all_or_nothing(self):
+        assert all_or_nothing(self.all_true, expression) == 1
+        assert all_or_nothing(self.all_false, expression) == 0
+        assert all_or_nothing(self.half, expression) == 0
+
+    def test_percent_match(self):
+        assert percent_match(self.all_true, expression) == 1
+        assert percent_match(self.all_false, expression) == 0
+        assert percent_match(self.half, expression) == 0.5
+
+    def test_percent_match_unique(self):
+        assert percent_match_unique(self.all_true, expression) == 0
+        assert percent_match_unique(self.all_false, expression) == 0
+        assert percent_match_unique(self.half, expression) == 0
+        assert percent_match_unique(self.all_true, even) == 0.5
+        assert percent_match_unique(self.all_false, even) == 0.5
+        assert percent_match_unique(self.half, even) == 1
+
+    def test_noise_match(self):
+        noise_match_func = noise_match(2)
+        assert abs(noise_match_func(self.all_true, expression) - log(.995)*10) < 0.00001
+        assert abs(noise_match_func(self.all_false, expression) - log(.005)*10) < 0.00001
+        assert abs(noise_match_func(self.half, expression) - (log(.995)*5 + log(.005)*5)) < 0.00001

--- a/src/tests/test_likelihood.py
+++ b/src/tests/test_likelihood.py
@@ -1,17 +1,25 @@
-from ultk.language.grammar.likelihood import all_or_nothing, percent_match_unique, percent_match, noise_match
+from ultk.language.grammar.likelihood import (
+    all_or_nothing,
+    percent_match_unique,
+    percent_match,
+    noise_match,
+)
 from math import log
+
 
 # The expression can simply act as a function for this purpose
 def expression(_):
     return True
 
+
 def even(i):
     return i % 2 == 0
+
 
 class TestLikelihood:
     all_true = [(i, True) for i in range(10)]
     all_false = [(i, False) for i in range(10)]
-    half = [(i, i%2 == 0) for i in range(10)]
+    half = [(i, i % 2 == 0) for i in range(10)]
 
     def test_all_or_nothing(self):
         assert all_or_nothing(self.all_true, expression) == 1
@@ -33,6 +41,17 @@ class TestLikelihood:
 
     def test_noise_match(self):
         noise_match_func = noise_match(2)
-        assert abs(noise_match_func(self.all_true, expression) - log(.995)*10) < 0.00001
-        assert abs(noise_match_func(self.all_false, expression) - log(.005)*10) < 0.00001
-        assert abs(noise_match_func(self.half, expression) - (log(.995)*5 + log(.005)*5)) < 0.00001
+        assert (
+            abs(noise_match_func(self.all_true, expression) - log(0.995) * 10) < 0.00001
+        )
+        assert (
+            abs(noise_match_func(self.all_false, expression) - log(0.005) * 10)
+            < 0.00001
+        )
+        assert (
+            abs(
+                noise_match_func(self.half, expression)
+                - (log(0.995) * 5 + log(0.005) * 5)
+            )
+            < 0.00001
+        )

--- a/src/ultk/language/grammar/grammar.py
+++ b/src/ultk/language/grammar/grammar.py
@@ -286,7 +286,9 @@ class Grammar:
 
     # @cache, unhashable, or embed it as a property (change every time Grammar is changed)
     def log_probability(self, rule: Rule) -> float:
-        return log(float(rule.weight)) - log(sum([r.weight for r in self._rules[rule.lhs]]))
+        return log(float(rule.weight)) - log(
+            sum([r.weight for r in self._rules[rule.lhs]])
+        )
 
     def prior(self, expr: GrammaticalExpression) -> float:
         """Prior of a GrammaticalExpression
@@ -384,13 +386,13 @@ class Grammar:
             raise ValueError("Could not parse string {expression}")
         return stack[0]
 
-    def generate(self, lhs: Any = None, max_depth = 3, depth = 0) -> GrammaticalExpression:
+    def generate(self, lhs: Any = None, max_depth=3, depth=0) -> GrammaticalExpression:
         """Generate an expression from a given lhs."""
         if lhs is None:
             lhs = self._start
         rules = self._rules[lhs]
         # Stop there from being a high chance of infinite recusion
-        if (depth > max_depth):
+        if depth > max_depth:
             filtered_rules = list(filter(lambda rule: rule.rhs is None, rules))
             if len(filtered_rules) != 0:
                 rules = filtered_rules
@@ -400,7 +402,12 @@ class Grammar:
         children = (
             None
             if the_rule.rhs is None
-            else tuple([self.generate(child_lhs, max_depth=max_depth, depth=depth + 1) for child_lhs in the_rule.rhs])
+            else tuple(
+                [
+                    self.generate(child_lhs, max_depth=max_depth, depth=depth + 1)
+                    for child_lhs in the_rule.rhs
+                ]
+            )
         )
         # if the rule is terminal, rhs will be empty, so no recursive calls to generate will be made in this comprehension
         return GrammaticalExpression(

--- a/src/ultk/language/grammar/grammar.py
+++ b/src/ultk/language/grammar/grammar.py
@@ -9,6 +9,7 @@ from itertools import product
 from typing import Any, Callable, Generator, TypedDict, TypeVar
 from yaml import load
 from functools import cache
+from math import log
 
 try:
     from yaml import CLoader as Loader
@@ -283,6 +284,10 @@ class Grammar:
     def probability(self, rule: Rule) -> float:
         return float(rule.weight) / sum([r.weight for r in self._rules[rule.lhs]])
 
+    # @cache, unhashable, or embed it as a property (change every time Grammar is changed)
+    def log_probability(self, rule: Rule) -> float:
+        return log(float(rule.weight)) - log(sum([r.weight for r in self._rules[rule.lhs]]))
+
     def prior(self, expr: GrammaticalExpression) -> float:
         """Prior of a GrammaticalExpression
 
@@ -296,6 +301,21 @@ class Grammar:
         children = expr.children if expr.children else ()
         for child in children:
             probability = probability * (self.prior(child))
+        return probability
+
+    def log_prior(self, expr: GrammaticalExpression) -> float:
+        """Prior of a GrammaticalExpression in log probability
+
+        Args:
+            expr (GrammaticalExpression): the GrammaticalExpression for compuation
+
+        Returns:
+            float: log prior
+        """
+        probability = self.log_probability(self._rules_by_name[expr.rule_name])
+        children = expr.children if expr.children else ()
+        for child in children:
+            probability = probability + (self.log_prior(child))
         return probability
 
     def parse(
@@ -364,18 +384,23 @@ class Grammar:
             raise ValueError("Could not parse string {expression}")
         return stack[0]
 
-    def generate(self, lhs: Any = None) -> GrammaticalExpression:
+    def generate(self, lhs: Any = None, max_depth = 3, depth = 0) -> GrammaticalExpression:
         """Generate an expression from a given lhs."""
         if lhs is None:
             lhs = self._start
         rules = self._rules[lhs]
+        # Stop there from being a high chance of infinite recusion
+        if (depth > max_depth):
+            filtered_rules = list(filter(lambda rule: rule.rhs is None, rules))
+            if len(filtered_rules) != 0:
+                rules = filtered_rules
         the_rule = random.choices(rules, weights=[rule.weight for rule in rules], k=1)[
             0
         ]
         children = (
             None
             if the_rule.rhs is None
-            else tuple([self.generate(child_lhs) for child_lhs in the_rule.rhs])
+            else tuple([self.generate(child_lhs, max_depth=max_depth, depth=depth + 1) for child_lhs in the_rule.rhs])
         )
         # if the rule is terminal, rhs will be empty, so no recursive calls to generate will be made in this comprehension
         return GrammaticalExpression(

--- a/src/ultk/language/grammar/grammar.py
+++ b/src/ultk/language/grammar/grammar.py
@@ -403,10 +403,8 @@ class Grammar:
             None
             if the_rule.rhs is None
             else tuple(
-                [
-                    self.generate(child_lhs, max_depth=max_depth, depth=depth + 1)
-                    for child_lhs in the_rule.rhs
-                ]
+                self.generate(child_lhs, max_depth=max_depth, depth=depth + 1)
+                for child_lhs in the_rule.rhs
             )
         )
         # if the rule is terminal, rhs will be empty, so no recursive calls to generate will be made in this comprehension

--- a/src/ultk/language/grammar/inference.py
+++ b/src/ultk/language/grammar/inference.py
@@ -39,9 +39,9 @@ def log_mh_sample(
         ) + (
             (old_subtree_prior + new_node_count) - (new_subtree_prior + old_node_count)
         )
-        if isnan(mh_accept) or isinf(mh_accept):
-            return False
-        if mh_accept >= 0 or random.random() < exp(mh_accept):
+        if not (isnan(mh_accept) or isinf(mh_accept)) and (
+            mh_accept >= 0 or random.random() < exp(mh_accept)
+        ):
             return new_tree
 
 

--- a/src/ultk/language/grammar/inference.py
+++ b/src/ultk/language/grammar/inference.py
@@ -34,16 +34,16 @@ def log_mh_sample(
         new_node_count = new_tree.node_count()
         new_subtree_prior = grammar.log_prior(new_node)
         mh_accept = (
-                (new_tree_prior + likelihood_func(data, new_tree))
-                - (old_tree_prior + likelihood_func(data, old_tree))
-            ) + (
-                (old_subtree_prior + new_node_count)
-                - (new_subtree_prior + old_node_count)
-            )
+            (new_tree_prior + likelihood_func(data, new_tree))
+            - (old_tree_prior + likelihood_func(data, old_tree))
+        ) + (
+            (old_subtree_prior + new_node_count) - (new_subtree_prior + old_node_count)
+        )
         if isnan(mh_accept) or isinf(mh_accept):
             return False
         if mh_accept >= 0 or random.random() < exp(mh_accept):
             return new_tree
+
 
 def mh_sample(
     expr: GrammaticalExpression,

--- a/src/ultk/language/grammar/inference.py
+++ b/src/ultk/language/grammar/inference.py
@@ -37,7 +37,7 @@ def log_mh_sample(
             (new_tree_prior + likelihood_func(data, new_tree))
             - (old_tree_prior + likelihood_func(data, old_tree))
         ) + (
-            (old_subtree_prior + new_node_count) - (new_subtree_prior + old_node_count)
+            (old_subtree_prior - new_node_count) - (new_subtree_prior - old_node_count)
         )
         if not (isnan(mh_accept) or isinf(mh_accept)) and (
             mh_accept >= 0 or random.random() < exp(mh_accept)

--- a/src/ultk/language/grammar/inference.py
+++ b/src/ultk/language/grammar/inference.py
@@ -29,6 +29,7 @@ def log_mh_sample(
     """
     old_tree_prior = grammar.log_prior(expr)
     old_node_count = log(expr.node_count())
+    old_tree_likelihood = likelihood_func(data, expr)
     while True:
         old_tree = copy.deepcopy(expr)
         current_node, parent_node = mh_select(old_tree)
@@ -39,7 +40,7 @@ def log_mh_sample(
         new_subtree_prior = grammar.log_prior(new_node)
         mh_accept = likelihood_weight * (
             (new_tree_prior + likelihood_func(data, new_tree))
-            - (old_tree_prior + likelihood_func(data, old_tree))
+            - (old_tree_prior + old_tree_likelihood)
         ) + subtree_weight * (
             (old_subtree_prior - new_node_count) - (new_subtree_prior - old_node_count)
         )
@@ -70,6 +71,7 @@ def mh_sample(
     """
     old_tree_prior = grammar.prior(expr)
     old_node_count = expr.node_count()
+    old_tree_likelihood = likelihood_func(data, expr)
     while True:
         old_tree = copy.deepcopy(expr)
         current_node, parent_node = mh_select(old_tree)
@@ -83,7 +85,7 @@ def mh_sample(
                 1,
                 (
                     (new_tree_prior * likelihood_func(data, new_tree))
-                    / (old_tree_prior * likelihood_func(data, old_tree))
+                    / (old_tree_prior * old_tree_likelihood)
                 )
                 * (
                     (old_subtree_prior / new_node_count)

--- a/src/ultk/language/grammar/inference.py
+++ b/src/ultk/language/grammar/inference.py
@@ -1,7 +1,7 @@
 from typing import TypeVar, Iterable, Callable
 from ultk.language.grammar.grammar import Grammar, GrammaticalExpression
 from ultk.language.grammar.likelihood import Dataset, all_or_nothing
-from math import isnan, isinf, exp
+from math import isnan, isinf, exp, log
 import copy
 import random
 
@@ -11,6 +11,8 @@ def log_mh_sample(
     grammar: Grammar,
     data: Dataset,
     likelihood_func: Callable[[Dataset, GrammaticalExpression], float] = all_or_nothing,
+    likelihood_weight: float = 1,
+    subtree_weight: float = 1,
 ) -> GrammaticalExpression:
     """Sample a new GrammaticalExpression from an exsiting one and data using Metropolis Hastings using log probabilities
 
@@ -19,28 +21,32 @@ def log_mh_sample(
         grammar (Grammar): the grammar for generation
         data (Dataset): data used for calculation of acceptance probability
         likelihood_func (Callable[[Dataset, GrammaticalExpression], float], optional): _description_. Defaults to all_or_nothing.
+        likelihood_weight (float, optional): Weight for the likelihood/prior of the full tree. Defaults to 1.
+        subtree_weight (float, optional): Weight for the subtree prior and length. Defaults to 1.
 
     Returns:
         GrammaticalExpression: newly sampled GrammaticalExpression
     """
     old_tree_prior = grammar.log_prior(expr)
-    old_node_count = expr.node_count()
+    old_node_count = log(expr.node_count())
     while True:
         old_tree = copy.deepcopy(expr)
         current_node, parent_node = mh_select(old_tree)
         old_subtree_prior = grammar.log_prior(current_node)
         new_tree, new_node = mh_generate(old_tree, current_node, parent_node, grammar)
         new_tree_prior = grammar.log_prior(new_tree)
-        new_node_count = new_tree.node_count()
+        new_node_count = log(new_tree.node_count())
         new_subtree_prior = grammar.log_prior(new_node)
-        mh_accept = (
+        mh_accept = likelihood_weight * (
             (new_tree_prior + likelihood_func(data, new_tree))
             - (old_tree_prior + likelihood_func(data, old_tree))
-        ) + (
+        ) + subtree_weight * (
             (old_subtree_prior - new_node_count) - (new_subtree_prior - old_node_count)
         )
-        if not (isnan(mh_accept) or isinf(mh_accept)) and (
-            mh_accept >= 0 or random.random() < exp(mh_accept)
+        if not (isnan(mh_accept) or (isinf(mh_accept) and mh_accept < 0)) and (
+            mh_accept >= 0
+            or random.random()
+            < exp(mh_accept)  # Perhaps change later if rounding errors occur
         ):
             return new_tree
 

--- a/src/ultk/language/grammar/likelihood.py
+++ b/src/ultk/language/grammar/likelihood.py
@@ -87,8 +87,9 @@ def noise_match(
     """
     correct_chance = log(1 - alpha + alpha / possible_outputs)
     incorrect_chance = log(alpha / possible_outputs)
+
     def noise_match_probability(data: Dataset, tree: GrammaticalExpression) -> float:
         matches = sum([tree(datum[0]) == datum[1] for datum in data])
-        return (len(data) - matches)*(incorrect_chance) + matches*(correct_chance)
+        return (len(data) - matches) * (incorrect_chance) + matches * (correct_chance)
 
     return noise_match_probability

--- a/src/ultk/language/grammar/likelihood.py
+++ b/src/ultk/language/grammar/likelihood.py
@@ -30,7 +30,7 @@ def percent_match(data: Dataset, tree: GrammaticalExpression) -> float:
     Returns:
         float: likelihood
     """
-    return sum([tree(datum[0]) == datum[1] for datum in data])/len(data)
+    return sum([tree(datum[0]) == datum[1] for datum in data]) / len(data)
 
 
 def percent_match_unique(data: Dataset, tree: GrammaticalExpression) -> float:
@@ -56,19 +56,24 @@ def percent_match_unique(data: Dataset, tree: GrammaticalExpression) -> float:
         total_matches += int(val == datum[1])
     if same:
         return 0
-    return total_matches/len(data)
+    return total_matches / len(data)
 
 
-def noise_match(possible_outputs: int, alpha: float = 0.01) -> Callable[[Dataset, GrammaticalExpression], float]:
+def noise_match(
+    possible_outputs: int, alpha: float = 0.01
+) -> Callable[[Dataset, GrammaticalExpression], float]:
     """Taken from Piantadosi et al. Attempts to discern the probability by believing that the output is correct
     and was passed through a noise function which has an `alpha` chance to corrupt each item in the output list.
+    
+    Takes in the number of possible values the output can be and the percent chance of a corruption and returns a
+    probability function which `mh_sample` is able to use.
 
     See also: https://github.com/piantado/LOTlib3/blob/master/Hypotheses/Likelihoods/BinaryLikelihood.py
 
     Args:
         possible_ouputs (int): The number of possible values an output is able to be
         alpha (float): The percentage chance that a value will be mutated
-    
+
     Returns:
         Callable likelihood function:
             Args:
@@ -77,7 +82,11 @@ def noise_match(possible_outputs: int, alpha: float = 0.01) -> Callable[[Dataset
             Returns:
                 float: likelihood
     """
+
     def noise_match_probability(data: Dataset, tree: GrammaticalExpression) -> float:
         matches = sum([tree(datum[0]) == datum[1] for datum in data])
-        return (alpha/possible_outputs)**(len(data)-matches) * (1-alpha + alpha/possible_outputs)**matches
+        return (alpha / possible_outputs) ** (len(data) - matches) * (
+            1 - alpha + alpha / possible_outputs
+        ) ** matches
+
     return noise_match_probability

--- a/src/ultk/language/grammar/likelihood.py
+++ b/src/ultk/language/grammar/likelihood.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Iterable
+from typing import Callable, TypeVar, Iterable
 from ultk.language.grammar.grammar import GrammaticalExpression
 from ultk.language.semantics import Referent
 
@@ -17,3 +17,67 @@ def all_or_nothing(data: Dataset, tree: GrammaticalExpression) -> float:
         float: likelihood
     """
     return float(all(tree(datum[0]) == datum[1] for datum in data))
+
+
+def percent_match(data: Dataset, tree: GrammaticalExpression) -> float:
+    """Basic percentage-based likelihood, returns the percent of matches across the output from the tree
+    and the expected output from the data
+
+    Args:
+        data (Dataset): data for likelihood calculation
+        tree (GrammaticalExpression): GrammaticalExpression for likelihood calculation
+
+    Returns:
+        float: likelihood
+    """
+    return sum([tree(datum[0]) == datum[1] for datum in data])/len(data)
+
+
+def percent_match_unique(data: Dataset, tree: GrammaticalExpression) -> float:
+    """Basic percentage-based likelihood, returns the percent of matches across the output from the tree
+    and the expected output from the data. However, if all of the outputs of the tree are the same returns 0.
+
+    Args:
+        data (Dataset): data for likelihood calculation
+        tree (GrammaticalExpression): GrammaticalExpression for likelihood calculation
+
+    Returns:
+        float: likelihood
+    """
+    first_value = None
+    same = True
+    total_matches = 0
+    for datum in data:
+        val = tree(datum[0])
+        if first_value is None:
+            first_value = val
+        elif same and val != first_value:
+            same = False
+        total_matches += int(val == datum[1])
+    if same:
+        return 0
+    return total_matches/len(data)
+
+
+def noise_match(possible_outputs: int, alpha: float = 0.01) -> Callable[[Dataset, GrammaticalExpression], float]:
+    """Taken from Piantadosi et al. Attempts to discern the probability by believing that the output is correct
+    and was passed through a noise function which has an `alpha` chance to corrupt each item in the output list.
+
+    See also: https://github.com/piantado/LOTlib3/blob/master/Hypotheses/Likelihoods/BinaryLikelihood.py
+
+    Args:
+        possible_ouputs (int): The number of possible values an output is able to be
+        alpha (float): The percentage chance that a value will be mutated
+    
+    Returns:
+        Callable likelihood function:
+            Args:
+                data (Dataset): data for likelihood calculation
+                tree (GrammaticalExpression): GrammaticalExpression for likelihood calculation
+            Returns:
+                float: likelihood
+    """
+    def noise_match_probability(data: Dataset, tree: GrammaticalExpression) -> float:
+        matches = sum([tree(datum[0]) == datum[1] for datum in data])
+        return (alpha/possible_outputs)**(len(data)-matches) * (1-alpha + alpha/possible_outputs)**matches
+    return noise_match_probability

--- a/src/ultk/util/frozendict.py
+++ b/src/ultk/util/frozendict.py
@@ -1,5 +1,6 @@
 from typing import Generic, TypeVar
 from yaml import YAMLObject
+from copy import deepcopy
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -10,6 +11,13 @@ class FrozenDict(dict[K, V], Generic[K, V], YAMLObject):
 
     def __hash__(self):
         return hash(frozenset(self.items()))
+
+    def __deepcopy__(self, memo):
+        output = FrozenDict(
+            {deepcopy(k, memo): deepcopy(v, memo) for k, v in self.items()}
+        )
+        memo[id(self)] = output
+        return output
 
     def __setitem__(self, key, value):
         raise TypeError("FrozenDict is immutable")


### PR DESCRIPTION
## Changes
- Adds `log_mh_sample`, which uses log probabilities to calculate the likelihood
  - Both `Grammar.log_prior` and `Grammar.log_probability` have been added
- Adds 4 new functions and respective documentation
  - `percent_match`: The percentage of matching outputs between tree and expected
  - `percent_match_unique`: The same as `percent_match` but returns 0 if all items are the same 
  - `noise_match`: From Piantadosi et al. Treats output as having noise applied and calculated probability that way
    - Written for `log_mh_sample`
  - `aggregate_individual_likelihoods` takes in a function which returns the probability of a single datum and returns a function which sums the log probabilities for all datums in the dataset
    - Written for `log_mh_sample` 
- Add tests for likelihood functions
## Notes
- Closes #59 
- Fixes bug with `mh_sample` where if the `expr.meaning` is not `None` then `copy.deepcopy` fails 
- Fixed bug with `mh_sample` where `mh_generate` would change `old_tree`, causing `likelihood_func(data, old_tree)` to be calculated incorrectly
  - `old_tree_likelihood` is now calculated beforehand using `expr`